### PR TITLE
Test with Python 3.5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py,py34
+envlist = py35
 
 [testenv]
 changedir=tests


### PR DESCRIPTION
Also remove the 'py' environment which just tests with whichever Python version `tox` was installed with which is somewhat arbitrary.