### PR TITLE
Added optional parameter for submitting request header data

### DIFF
--- a/src/activesoup/driver.py
+++ b/src/activesoup/driver.py
@@ -56,8 +56,8 @@ class Driver:
 
         return urljoin(current_url_str, possibly_relative_url)
 
-    def get(self, url, **kwargs):
-        return self.do(requests.Request(method="GET", url=url))
+    def get(self, url, headers=None, **kwargs):
+        return self.do(requests.Request(method="GET", url=url, headers=headers))
 
     def do(self, request: requests.Request) -> "Driver":
         request.url = self.resolve_url(request.url)


### PR DESCRIPTION
In general, activesoup works like a charm (thanks!). The web site that I want to scrape data from requires me to set the user agent (read: I need to be able to submit this information as part of the request header information)